### PR TITLE
Feat/#4

### DIFF
--- a/mobile2/src/main/java/sopt/mobile2/controller/RecentTransferController.java
+++ b/mobile2/src/main/java/sopt/mobile2/controller/RecentTransferController.java
@@ -1,0 +1,26 @@
+package sopt.mobile2.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.mobile2.dto.RecentTransferResponse;
+import sopt.mobile2.service.RecentTransferService;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recent-transfers")
+public class RecentTransferController {
+
+    private final RecentTransferService recentTransferService;
+
+    @GetMapping("/{accountId}")
+    public ResponseEntity<List<RecentTransferResponse>> getRecentTransfersByAccount(@PathVariable(name="accountId") Long accountId) {
+        List<RecentTransferResponse> response = recentTransferService.recentTransferList(accountId);
+        return ResponseEntity.ok(response);
+    }
+}
+

--- a/mobile2/src/main/java/sopt/mobile2/domain/Transfer.java
+++ b/mobile2/src/main/java/sopt/mobile2/domain/Transfer.java
@@ -2,6 +2,9 @@ package sopt.mobile2.domain;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -23,4 +26,7 @@ public class Transfer{
     private int transferAmount;
 
     private int month;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 }

--- a/mobile2/src/main/java/sopt/mobile2/dto/RecentTransferResponse.java
+++ b/mobile2/src/main/java/sopt/mobile2/dto/RecentTransferResponse.java
@@ -1,0 +1,28 @@
+package sopt.mobile2.dto;
+
+import java.time.LocalDateTime;
+
+
+public record RecentTransferResponse(
+        String accountName,
+        int accountNumber,
+        boolean accountLike,
+        LocalDateTime createdAt
+) {
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public int getAccountNumber() {
+        return accountNumber;
+    }
+
+    public boolean isAccountLike() {
+        return accountLike;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/mobile2/src/main/java/sopt/mobile2/repository/BookmarkRepository.java
+++ b/mobile2/src/main/java/sopt/mobile2/repository/BookmarkRepository.java
@@ -1,0 +1,9 @@
+package sopt.mobile2.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.mobile2.domain.BookMark;
+
+public interface BookmarkRepository extends JpaRepository<BookMark, Long> {
+    boolean existsByMarkedAccountId(Long accountId);
+}
+

--- a/mobile2/src/main/java/sopt/mobile2/repository/TransferRepository.java
+++ b/mobile2/src/main/java/sopt/mobile2/repository/TransferRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface TransferRepository extends JpaRepository<Transfer, Long> {
     List<Transfer> findByMyAccountIdAndMonth(Long accountId, int month);
+    List<Transfer> findByMyAccountId(Long accountId);
 }

--- a/mobile2/src/main/java/sopt/mobile2/service/RecentTransferService.java
+++ b/mobile2/src/main/java/sopt/mobile2/service/RecentTransferService.java
@@ -24,7 +24,6 @@ public class RecentTransferService {
     public List<RecentTransferResponse> recentTransferList(Long accountId) {
         List<Transfer> transfers = transferRepository.findByMyAccountId(accountId);
 
-        // LinkedHashMap을 사용하여 중복된 수신 계좌를 최신 정보로 업데이트하고 유지합니다.
         Map<Long, RecentTransferResponse> uniqueTransfers = transfers.stream()
                 .collect(Collectors.toMap(
                         transfer -> transfer.getReceiveAccount().getId(),

--- a/mobile2/src/main/java/sopt/mobile2/service/RecentTransferService.java
+++ b/mobile2/src/main/java/sopt/mobile2/service/RecentTransferService.java
@@ -1,0 +1,49 @@
+package sopt.mobile2.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sopt.mobile2.domain.Account;
+import sopt.mobile2.domain.Transfer;
+import sopt.mobile2.dto.RecentTransferResponse;
+import sopt.mobile2.repository.BookmarkRepository;
+import sopt.mobile2.repository.TransferRepository;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RecentTransferService {
+
+    private final TransferRepository transferRepository;
+    private final BookmarkRepository bookmarkRepository;
+
+    public List<RecentTransferResponse> recentTransferList(Long accountId) {
+        List<Transfer> transfers = transferRepository.findByMyAccountId(accountId);
+
+        // LinkedHashMap을 사용하여 중복된 수신 계좌를 최신 정보로 업데이트하고 유지합니다.
+        Map<Long, RecentTransferResponse> uniqueTransfers = transfers.stream()
+                .collect(Collectors.toMap(
+                        transfer -> transfer.getReceiveAccount().getId(),
+                        transfer -> new RecentTransferResponse(
+                                transfer.getReceiveAccount().getAccountName(),
+                                transfer.getReceiveAccount().getAccountNumber(),
+                                isFavorite(transfer.getReceiveAccount()),
+                                transfer.getCreatedAt()),
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
+                ));
+
+        return uniqueTransfers.values().stream()
+                .sorted(Comparator.comparing(RecentTransferResponse::isAccountLike).reversed()
+                        .thenComparing(RecentTransferResponse::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isFavorite(Account account){
+        return bookmarkRepository.existsByMarkedAccountId(account.getId());
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #4 

## Key Changes 🔑
- 최근 이체한 계좌 목록이 List로 반환되는 GET API
   즐겨찾기한 계정들이 먼저 앞쪽으로 오게 정렬한 후, 나머지 계정들 정렬해서 하나의 list로 받아오기!
   즉, 즐겨찾기 여부에 대한 불리언 타입을 JSON에 같이 껴 넣어서 보내줌.

- 즐겨찾기 true인 최근 이체 계좌를 맨 위에 정렬하되, 즐겨찾기 true인 계좌 내에서도 최근 이체된 계좌가 맨 위에 뜨도록 정렬했습니다.
- 이체 시간을 알 수 있도록 Transfer 클래스에 LocalDatatime형 createAt 필드를 추가했습니다.

### 실행결과 설명입니다
- account 테이블
![image](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-Server/assets/128598386/f0bfc7e2-8e0a-4477-b4ed-a91189376a95)
8개의 계좌를 생성했습니다.

- book_mark 테이블
![image](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-Server/assets/128598386/147641ac-051e-476a-b1fa-c9faff3349b3)
1번(조영주) 계좌가 2,4,5번 계좌를 즐겨찾기 설정 했음을 알 수 있습니다.

- transfer 테이블
![image](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-Server/assets/128598386/2841781a-63f7-4e18-ba5e-169c6ef96d6b)
created_at 에서 각 이체 내역 별 이체 시간을 설정해 줬습니다.
1번 계좌를 예시로 들면, 1번 계좌는 2 > 4 > 7 > 5 계좌 순으로 이체를 진행했습니다.

- GET 결과
![image](https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-Server/assets/128598386/705b021d-f89d-4c57-8038-2d43f6740b13)
즐겨찾기 true 인 계좌들이 상위에 정렬됩니다.
이 중에서도 가장 최근에 이체 이력이 있는 5번이 가장 위에 정렬되며, 따라서 즐겨찾기 true인 계좌 내에서도 5 > 4 > 2 순으로 정렬되어 있는 것을 확인할 수 있습니다.


## To Reviewers 📢
- 확인 후 카톡 부탁드립니다! 다들 홧팅팟팅 ~~