### PR TITLE
Feat/#10

### DIFF
--- a/mobile2/src/main/java/sopt/mobile2/controller/MonthlyTransferController.java
+++ b/mobile2/src/main/java/sopt/mobile2/controller/MonthlyTransferController.java
@@ -1,0 +1,21 @@
+package sopt.mobile2.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sopt.mobile2.dto.MonthlyTransferRequestDto;
+import sopt.mobile2.service.MonthlyTransferService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/transfer-list")
+public class MonthlyTransferController {
+
+    private final MonthlyTransferService monthlyTransferService;
+
+    @GetMapping("")
+    public ResponseEntity getTransferListByMonth(@RequestParam(name = "month") int month,
+                                                 @RequestBody MonthlyTransferRequestDto requestDto) {
+        return ResponseEntity.ok(monthlyTransferService.getTransferByMonth(month, requestDto));
+    }
+}

--- a/mobile2/src/main/java/sopt/mobile2/domain/Transfer.java
+++ b/mobile2/src/main/java/sopt/mobile2/domain/Transfer.java
@@ -25,8 +25,11 @@ public class Transfer{
     //거래액
     private int transferAmount;
 
-    //거래 후 내 계좌의 남은 잔액
+    //거래 후 송금 계좌의 남은 잔액
     private int myAccountBalance;
+
+    //거래 후 송금 받은 계좌의 남은 잔액
+    private int receiveAccountBalance;
 
     private int month;
 

--- a/mobile2/src/main/java/sopt/mobile2/domain/Transfer.java
+++ b/mobile2/src/main/java/sopt/mobile2/domain/Transfer.java
@@ -25,6 +25,9 @@ public class Transfer{
     //거래액
     private int transferAmount;
 
+    //거래 후 내 계좌의 남은 잔액
+    private int myAccountBalance;
+
     private int month;
 
     @CreationTimestamp

--- a/mobile2/src/main/java/sopt/mobile2/dto/MonthlyTransferByMe.java
+++ b/mobile2/src/main/java/sopt/mobile2/dto/MonthlyTransferByMe.java
@@ -1,0 +1,4 @@
+package sopt.mobile2.dto;
+
+public record MonthlyTransferByMe() {
+}

--- a/mobile2/src/main/java/sopt/mobile2/dto/MonthlyTransferRequestDto.java
+++ b/mobile2/src/main/java/sopt/mobile2/dto/MonthlyTransferRequestDto.java
@@ -1,0 +1,4 @@
+package sopt.mobile2.dto;
+
+public record MonthlyTransferRequestDto(Long accountId) {
+}

--- a/mobile2/src/main/java/sopt/mobile2/dto/MonthlyTransferResponseDto.java
+++ b/mobile2/src/main/java/sopt/mobile2/dto/MonthlyTransferResponseDto.java
@@ -1,0 +1,7 @@
+package sopt.mobile2.dto;
+
+import sopt.mobile2.domain.Transfer;
+
+public record MonthlyTransferResponseDto(String accountName, String date,
+                                         int transferAmount, int balance) {
+}

--- a/mobile2/src/main/java/sopt/mobile2/repository/TransferRepository.java
+++ b/mobile2/src/main/java/sopt/mobile2/repository/TransferRepository.java
@@ -9,4 +9,5 @@ public interface TransferRepository extends JpaRepository<Transfer, Long> {
     List<Transfer> findByMyAccountIdAndMonth(Long accountId, int month);
     List<Transfer> findByReceiveAccountIdAndMonth(Long accountId, int month);
     List<Transfer> findByMyAccountId(Long accountId);
+    List<Transfer> findByMyAccountIdOrReceiveAccountIdAndMonthOrderByCreatedAtDesc(Long accountId, Long receiveAccountId,int month);
 }

--- a/mobile2/src/main/java/sopt/mobile2/service/MonthlyTransferService.java
+++ b/mobile2/src/main/java/sopt/mobile2/service/MonthlyTransferService.java
@@ -28,7 +28,7 @@ public class MonthlyTransferService {
                                 parseLocalDateTimeToMonthAndDate(transfer.getCreatedAt()), -transfer.getTransferAmount(),transfer.getMyAccountBalance()));
                     } else if (transfer.getReceiveAccount().getId().equals(requestDto.accountId())){
                         result.add(new MonthlyTransferResponseDto(transfer.getMyAccount().getAccountName(),
-                                parseLocalDateTimeToMonthAndDate(transfer.getCreatedAt()), transfer.getTransferAmount(),transfer.getMyAccountBalance()));
+                                parseLocalDateTimeToMonthAndDate(transfer.getCreatedAt()), transfer.getTransferAmount(),transfer.getReceiveAccountBalance()));
                     }
                 }
         );

--- a/mobile2/src/main/java/sopt/mobile2/service/MonthlyTransferService.java
+++ b/mobile2/src/main/java/sopt/mobile2/service/MonthlyTransferService.java
@@ -1,0 +1,48 @@
+package sopt.mobile2.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sopt.mobile2.domain.Transfer;
+import sopt.mobile2.dto.MonthlyTransferRequestDto;
+import sopt.mobile2.dto.MonthlyTransferResponseDto;
+import sopt.mobile2.repository.TransferRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyTransferService {
+
+    private final TransferRepository transferRepository;
+
+    public List<MonthlyTransferResponseDto> getTransferByMonth(int month, MonthlyTransferRequestDto requestDto) {
+        List<MonthlyTransferResponseDto> result = new ArrayList<>();
+        List<Transfer> findTransfer = transferRepository.findByMyAccountIdOrReceiveAccountIdAndMonthOrderByCreatedAtDesc(
+                requestDto.accountId(), requestDto.accountId(), month);
+
+        findTransfer.forEach(
+                transfer -> {
+                    if(transfer.getMyAccount().getId().equals(requestDto.accountId())) {
+                        result.add(new MonthlyTransferResponseDto(transfer.getReceiveAccount().getAccountName(),
+                                parseLocalDateTimeToMonthAndDate(transfer.getCreatedAt()), -transfer.getTransferAmount(),transfer.getMyAccountBalance()));
+                    } else if (transfer.getReceiveAccount().getId().equals(requestDto.accountId())){
+                        result.add(new MonthlyTransferResponseDto(transfer.getMyAccount().getAccountName(),
+                                parseLocalDateTimeToMonthAndDate(transfer.getCreatedAt()), transfer.getTransferAmount(),transfer.getMyAccountBalance()));
+                    }
+                }
+        );
+        return result;
+    }
+
+    private String parseLocalDateTimeToMonthAndDate(LocalDateTime localDateTime) {
+        String month = Integer.toString(localDateTime.getMonthValue());
+        if(month.length() == 1) {
+            month = "0" + month;
+        }
+        String day = Integer.toString(localDateTime.getDayOfMonth());
+
+        return month + "." + day;
+    }
+
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #10 

## Key Changes 🔑
1. 내용
- 월별 거래 내역을 조회하는 API 입니다. 
- Transfer 엔티티에서 송금한 계좌와 송금 받은 계좌의 잔액 필드를 추가했습니다. 거래 후 남은 잔액을 표시할 방법이 Transfer 엔티티에 작성하는 것 말곤 없는 것 같아요
- Transfer의 myAccountId가 클라이언트로부터 전달받은 Id일 경우와, receiveAccountId가 해당 Id일 경우를 나누어 서비스 코드를 작성했습니다.
    - myAccountId일 경우 내가 송금한 경우이므로, Dto의 상대방 계좌 이름인 accontName 필드에 receiveAccountId의 계좌 이름을 집어넣었고, receiveId일 경우 그와 반대로 했습니다.

## 리턴 결과
- Datagrip으로 더미데이터를 넣어서 테스트해봤습니다. AccountId 2는 내 계좌이고, AccountId 3은 "햄통장"입니다. 거래 전 
balance는 각 계좌 10000입니다.
- 아래 두 사진은 가로로 연결된건데 길어서 두개로 나눠서 올립니다.
<img width="878" alt="image" src="https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-Server/assets/121341289/1b78d250-f57d-48c9-bd45-ce4485bdbecb">
<img width="503" alt="image" src="https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-Server/assets/121341289/4886dc18-315c-4ea6-90f0-e5201529452c">


-----------------------------------------------------------------------------
- Postman 테스트
<img width="245" alt="image" src="https://github.com/NOW-SOPT-APP2-KAKAOBANK/KAKAOBANK-Server/assets/121341289/117abea5-5523-4941-a7ae-378837725027">

## To Reviewers 📢
- 생각보다 쿼리와 코드가 복잡해진 것 같아서 수정 해보겠습니다.....