### PR TITLE
[fix] 즐겨찾기 POST 중복 방지

### DIFF
--- a/mobile2/src/main/java/sopt/mobile2/repository/BookMarkRepository.java
+++ b/mobile2/src/main/java/sopt/mobile2/repository/BookMarkRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 public interface BookMarkRepository extends JpaRepository<BookMark, Long> {
     boolean existsByMarkedAccountId(Long accountId);
+    boolean existsByMyAccountIdAndMarkedAccountId(Long myAccountId, Long markedAccountId);
     Optional<BookMark> findByMyAccountIdAndMarkedAccountId(Long myAccountId, Long markedAccountId);
 }
 

--- a/mobile2/src/main/java/sopt/mobile2/service/RecentTransferService.java
+++ b/mobile2/src/main/java/sopt/mobile2/service/RecentTransferService.java
@@ -57,17 +57,19 @@ public class RecentTransferService {
 
     @Transactional
     public void addBookMark(Long myAccountId, Long markedAccountId) {
-        Account myAccount = accountRepository.findById(myAccountId)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid myAccount ID"));
-        Account markedAccount = accountRepository.findById(markedAccountId)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid markedAccount ID"));
 
-        BookMark bookMark = BookMark.builder()
-                .myAccount(myAccount)
-                .markedAccount(markedAccount)
-                .build();
+        if(!bookmarkRepository.existsByMyAccountIdAndMarkedAccountId(myAccountId, markedAccountId)) {
+            Account myAccount = accountRepository.findById(myAccountId)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid myAccount ID"));
+            Account markedAccount = accountRepository.findById(markedAccountId)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid markedAccount ID"));
 
-        bookmarkRepository.save(bookMark);
+            BookMark bookMark = BookMark.builder()
+                    .myAccount(myAccount)
+                    .markedAccount(markedAccount)
+                    .build();
+            bookmarkRepository.save(bookMark);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## 수정한 부분
- BookMarkRepository에 existsByMyAccountIdAndMarkedAccountId() 메소드 추가 후 서비스 로직에서 조건문 처리